### PR TITLE
Fix Grid and Banner

### DIFF
--- a/src/components/molecules/Banner/Banner.tsx
+++ b/src/components/molecules/Banner/Banner.tsx
@@ -35,14 +35,16 @@ export const Banner: FC<Props> = ({
     <SectionContainer background={backgroundColor}>
       <StyledBanner className={className}>
         <StyledSection className={`${imageOuter ? "image-outer" : "image-inner"}`}>
-          <Typography variant={titleVariant} as="h3" color={titleColor} fontWeight="700">
-            {title}
-          </Typography>
-          {subtitle && (
-            <Typography color={theme.colors.gray300} variant="body_text_4">
-              {subtitle}
+          <div className="grid-area">
+            <Typography variant={titleVariant} as="h3" color={titleColor} fontWeight="700">
+              {title}
             </Typography>
-          )}
+            {subtitle && (
+              <Typography color={theme.colors.gray300} variant="body_text_4">
+                {subtitle}
+              </Typography>
+            )}
+          </div>
           <StyledChildren className="grid-area">{children}</StyledChildren>
           {imageInner && (
             <StyledBannerImage className="grid-area inner">

--- a/src/components/molecules/Grid/StyledGrid.tsx
+++ b/src/components/molecules/Grid/StyledGrid.tsx
@@ -21,7 +21,7 @@ export const StyledGrid = styled(StyledResponsiveContainer)`
       grid-template-columns: repeat(5, 1fr);
     }
     .grid-item {
-      &:first-child {
+      &:nth-child(5) {
         display: none;
         @media ${device.tablet} {
           display: block;


### PR DESCRIPTION
There was an issue with the Grid, didn't display 5-items-grid on small media
It was caused by display none on 1st child grid-item,
when changed it for 5th child
problem was fixed.
Added a wrapper to title in the Banner, the 'grid-area' class was missing
on that component