### PR TITLE
Change querySelector for refs

### DIFF
--- a/src/components/molecules/ImagesSwiper/ImagesSwiper.tsx
+++ b/src/components/molecules/ImagesSwiper/ImagesSwiper.tsx
@@ -15,20 +15,18 @@ import {
 } from "./StyledImagesSwiper";
 
 export const ImagesSwiper: FC = () => {
-  type RefType = React.MutableRefObject<null>;
-
-  const swiperImagePrevRef: RefType = useRef(null);
-  const swiperImageNextRef: RefType = useRef(null);
+  const swiperImagePrevRef = useRef<HTMLDivElement | null>(null);
+  const swiperImageNextRef = useRef<HTMLDivElement | null>(null);
   const [disableNext, setDisableNext] = useState(true);
   const [disablePrev, setDisablePrev] = useState(true);
 
   const handleClick = () => {
-    const elNext = document.querySelector("#next");
-    const elPrev = document.querySelector("#prev");
-    if (elNext?.classList.contains("swiper-button-disabled")) {
+    const targetNext = swiperImageNextRef.current;
+    const targetPrev = swiperImagePrevRef.current;
+    if (targetNext?.classList.contains("swiper-button-disabled")) {
       setDisableNext(true);
     } else setDisableNext(false);
-    if (elPrev?.classList.contains("swiper-button-disabled")) {
+    if (targetPrev?.classList.contains("swiper-button-disabled")) {
       setDisablePrev(true);
     } else setDisablePrev(false);
   };

--- a/src/components/molecules/TestimonialsSwiper/TestimonialsSwiper.tsx
+++ b/src/components/molecules/TestimonialsSwiper/TestimonialsSwiper.tsx
@@ -16,11 +16,11 @@ import {
 } from "./StyledTestimonialsSwiper";
 
 export const TestimonialsSwiper: FC = () => {
-  const swiperPrevRef = useRef(null);
-  const swiperNextRef = useRef(null);
+  const swiperPrevRef = useRef<HTMLDivElement | null>(null);
+  const swiperNextRef = useRef<HTMLDivElement | null>(null);
 
   return (
-    <StyledTestimonialsSwiper className="S-wiper">
+    <StyledTestimonialsSwiper className="swiper">
       <Typography
         as="h3"
         color={theme.colors.gray300}

--- a/src/libs/swiper/swiperData.ts
+++ b/src/libs/swiper/swiperData.ts
@@ -1,6 +1,6 @@
 import React from "react";
 
-type RefType = React.MutableRefObject<null>;
+type RefType = { current: HTMLDivElement | null };
 
 export const onInit = (swiperPrevRef: RefType, swiperNextRef: RefType, swiper: any) => {
   swiper.params.navigation.prevEl = swiperPrevRef.current;


### PR DESCRIPTION
Function on nav buttons click
in ImagesSwiper changed from using querySelector to "ref" to access
classlist property of current.
Added proper types to refs.