### PR TITLE
Menu 

### DIFF
--- a/src/assets/content/developers.ts
+++ b/src/assets/content/developers.ts
@@ -1,5 +1,6 @@
 import { backend, frontend, mobile, magento, salesforce, awsCloud } from "../icons";
 import { ROUTE } from "../../routes";
+
 export const developers = [
   {
     type: "backend developers",
@@ -35,7 +36,7 @@ export const developers = [
     ],
     description: `We support all major backend technologies.`,
     icon: `${backend}`,
-    id: "1",
+    id: "devs-1",
   },
   {
     type: "frontend developers",
@@ -55,7 +56,7 @@ export const developers = [
     ],
     description: `We're specialists in React, Angular & Vue.js.`,
     icon: `${frontend}`,
-    id: "2",
+    id: "devs-2",
   },
   {
     type: "mobile developers",
@@ -75,7 +76,7 @@ export const developers = [
     ],
     description: `Launching a new app ? Lets's do it! iOS, Android & React Native.`,
     icon: `${mobile}`,
-    id: "3",
+    id: "devs-3",
   },
   {
     type: "AWS Cloud Engineers",
@@ -87,7 +88,7 @@ export const developers = [
     ],
     description: `We've done it all from basic to advanced AWS infrastructure.`,
     icon: `${awsCloud}`,
-    id: "4",
+    id: "devs-4",
   },
   {
     type: "Salesforce developers",
@@ -99,7 +100,7 @@ export const developers = [
     ],
     description: `Take advantage of Salesforce, we've got you covered.`,
     icon: `${salesforce}`,
-    id: "5",
+    id: "devs-5",
   },
   {
     type: "Magento",
@@ -111,6 +112,6 @@ export const developers = [
     ],
     description: `We're experts in .Net framework/Core.`,
     icon: `${magento}`,
-    id: "6",
+    id: "devs-6",
   },
 ];

--- a/src/assets/content/navMenu/cards.ts
+++ b/src/assets/content/navMenu/cards.ts
@@ -1,0 +1,27 @@
+import { ROUTE } from "../../../routes";
+
+export const whatWeDoCards = [
+  {
+    title: "What We Do",
+    text: "Trusted developers, ready to join your team",
+    path: ROUTE.OUTSOURCE,
+  },
+  {
+    title: "FAQ's",
+    text: "Got burning questions? We've got the answers",
+    path: ROUTE.OUTSOURCE,
+  },
+];
+
+export const aboutUsCards = [
+  {
+    title: "About Sofomo",
+    text: "We are Sofomo! Learn about our story, leaders & values.",
+    path: ROUTE.OUTSOURCE,
+  },
+  {
+    title: "Careers",
+    text: "We're makers, doers & innovators. Ready to join us?",
+    path: ROUTE.OUTSOURCE,
+  },
+];

--- a/src/assets/content/navMenu/mainMenu.ts
+++ b/src/assets/content/navMenu/mainMenu.ts
@@ -1,9 +1,9 @@
 import { ROUTE } from "../../../routes";
 
 export const mainMenu = [
-  { title: "what we do", chevron: true, id: "1" },
-  { title: "our developers", chevron: true, id: "2" },
-  { title: "ROUTE.Outsource", chevron: false, id: "3", path: ROUTE.OUTSOURCE },
-  { title: "clients", chevron: false, id: "4", path: ROUTE.OUTSOURCE },
-  { title: "about us", chevron: true, id: "5" },
+  { title: "what we do", chevron: true, id: "menu-1" },
+  { title: "our developers", chevron: true, id: "menu-2" },
+  { title: "Outsource", chevron: false, id: "menu-3", path: ROUTE.OUTSOURCE },
+  { title: "clients", chevron: false, id: "menu-4", path: ROUTE.OUTSOURCE },
+  { title: "about us", chevron: true, id: "menu-5" },
 ];

--- a/src/components/molecules/List/StyledList.tsx
+++ b/src/components/molecules/List/StyledList.tsx
@@ -12,22 +12,7 @@ export const StyledList = styled.div<Props>`
   flex-direction: column;
   margin: ${({ margin }) => margin};
   &.standard {
-    &.developers {
-      &.inner {
-        padding-left: 3.5rem;
-        margin: 1rem 0 0 0;
-      }
-      &.outer {
-        border: 2px;
-        padding: 1.5rem;
-        margin: 0;
-        &:hover {
-          background-color: ${theme.colors.blueTransparent};
-          transition: all 0.3s;
-          border-radius: 4px;
-        }
-      }
-    }
+    flex-direction: column;
   }
   &.plain {
     width: max-content;

--- a/src/context/NavItemStateContext.tsx
+++ b/src/context/NavItemStateContext.tsx
@@ -1,0 +1,42 @@
+import React, { useState, createContext, FC, ReactNode, SetStateAction, useContext } from "react";
+
+interface Props {
+  children?: ReactNode;
+}
+
+type NavItemContextState = {
+  navItemActive: boolean;
+  setNavItemActive: React.Dispatch<SetStateAction<boolean>>;
+};
+
+const contextValues: NavItemContextState = {
+  navItemActive: false,
+  setNavItemActive: () => {},
+};
+
+export const NavItemStateCtx = createContext<NavItemContextState>(contextValues);
+
+export const useNavItemStateContext = () => {
+  const context = useContext(NavItemStateCtx);
+
+  if (context === undefined) {
+    throw new Error("usage of useNavItemStateContext not wrapped in `NavItemStateContext`.");
+  }
+
+  return context;
+};
+
+const NavItemStateContext = ({ children }: Props) => {
+  const [navItemActive, setNavItemActive] = useState(contextValues.navItemActive);
+  return (
+    <NavItemStateCtx.Provider
+      value={{
+        navItemActive,
+        setNavItemActive,
+      }}
+    >
+      {children}
+    </NavItemStateCtx.Provider>
+  );
+};
+export default NavItemStateContext;

--- a/src/context/PageOverlayContext.tsx
+++ b/src/context/PageOverlayContext.tsx
@@ -1,0 +1,36 @@
+import React, { useState, createContext, SetStateAction, ReactNode, useContext } from "react";
+
+interface Props {
+  children?: ReactNode;
+}
+
+type PageOverlayContextState = {
+  pageOverlayActive: boolean;
+  setPageOverlayActive: React.Dispatch<SetStateAction<boolean>>;
+};
+
+const contextValues: PageOverlayContextState = {
+  pageOverlayActive: false,
+  setPageOverlayActive: () => {},
+};
+
+export const PageOverlayCtx = createContext<PageOverlayContextState>(contextValues);
+
+export const usePageOverlayContext = () => {
+  const context = useContext(PageOverlayCtx);
+
+  if (context === undefined) {
+    throw new Error("usage of usePageOverlayContext not wrapped in `PageOverlayContext`.");
+  }
+
+  return context;
+};
+const PageOverlayContext = ({ children }: Props) => {
+  const [pageOverlayActive, setPageOverlayActive] = useState(contextValues.pageOverlayActive);
+  return (
+    <PageOverlayCtx.Provider value={{ pageOverlayActive, setPageOverlayActive }}>
+      {children}
+    </PageOverlayCtx.Provider>
+  );
+};
+export default PageOverlayContext;

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,1 +1,11 @@
 export { default as ContactFormContext, ContactFormCtx } from "./ContactFormContext";
+export {
+  default as NavItemStateContext,
+  NavItemStateCtx,
+  useNavItemStateContext,
+} from "./NavItemStateContext";
+export {
+  default as PageOverlayContext,
+  PageOverlayCtx,
+  usePageOverlayContext,
+} from "./PageOverlayContext";

--- a/src/keyframes/index.ts
+++ b/src/keyframes/index.ts
@@ -3,3 +3,5 @@ export { currencyLoop } from "./currencyLoop";
 export { modalScaleUp, modalScaleDown } from "./modalAnimation";
 export { hideCard, showCard } from "./cardWhiteAnimation";
 export { showForm } from "./outsourceFormAnimation";
+export { menuLineFadeOut, menuLineFadeIn } from "./menuLineAnimations";
+export { navItemSlideUp, navItemSlideDown, navItemFadeIn } from "./navItemAnimations";

--- a/src/keyframes/menuLineAnimations.ts
+++ b/src/keyframes/menuLineAnimations.ts
@@ -1,0 +1,23 @@
+import { keyframes } from "styled-components";
+import { theme } from "../themes/MainTheme";
+
+export const menuLineFadeIn = () => keyframes`
+  0% {
+    box-shadow: 0 0 0 0 ${theme.colors.shadow};
+  }
+  100% {
+    box-shadow: 0 1px 0 0 ${theme.colors.shadow};
+  }
+`;
+
+export const menuLineFadeOut = () => keyframes`
+  0% {
+    box-shadow: 0 1px 0 0 ${theme.colors.shadow};
+  }
+  50% {
+    box-shadow: 0 0.5px 0 0 ${theme.colors.shadow};
+  }
+  100% {
+    box-shadow: 0 0 0 0 ${theme.colors.shadow};
+  }
+`;

--- a/src/keyframes/navItemAnimations.ts
+++ b/src/keyframes/navItemAnimations.ts
@@ -1,0 +1,46 @@
+import { keyframes } from "styled-components";
+
+export const navItemSlideUp = () => keyframes`
+  0% {
+      height: max-content;
+      transform: translateY(0);
+      opacity: 1;
+    }
+    25% {
+      transform: translateY(-25px);
+      opacity: 0.5;
+    }
+    50% {
+      transform: translateY(-50px);
+      opacity: 0.75;
+    }
+    50% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 0;
+      transform: translateY(-150%);
+    }
+`;
+
+export const navItemSlideDown = () => keyframes`
+    0% {
+      transform: translateY(-50px);
+      opacity: 0;
+    }
+
+    100% {
+      height: max-content;
+      transform: translateY(0);
+      opacity: 1;
+    }
+`;
+
+export const navItemFadeIn = () => keyframes`
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+`;

--- a/src/organisms/Menu/Menu.stories.tsx
+++ b/src/organisms/Menu/Menu.stories.tsx
@@ -1,0 +1,36 @@
+import React, { useContext } from "react";
+import { Meta, Story } from "@storybook/react";
+import { BrowserRouter } from "react-router-dom";
+import { Menu } from "./Menu";
+import {
+  NavItemStateContext,
+  NavItemStateCtx,
+  PageOverlayContext,
+  PageOverlayCtx,
+} from "../../context";
+
+export default {
+  title: "Organisms/Menu",
+  component: Menu,
+} as Meta;
+
+const Template: Story = (args) => {
+  const { setPageOverlayActive } = useContext(PageOverlayCtx);
+  const { setNavItemActive } = useContext(NavItemStateCtx);
+
+  const closeMenu = () => {
+    setNavItemActive(false);
+    setPageOverlayActive(false);
+  };
+  return (
+    <NavItemStateContext>
+      <PageOverlayContext>
+        <BrowserRouter>
+          <Menu closeMenu={closeMenu} />
+        </BrowserRouter>
+      </PageOverlayContext>
+    </NavItemStateContext>
+  );
+};
+
+export const Default = Template.bind({});

--- a/src/organisms/Menu/Menu.tsx
+++ b/src/organisms/Menu/Menu.tsx
@@ -45,6 +45,7 @@ export const Menu = ({ closeMenu }: Props) => {
       setNavItemActive(true);
       if (navBtnPath) {
         setPageOverlayActive(false);
+        setNavItemActive(false);
       } else setPageOverlayActive(true);
     }
   };

--- a/src/organisms/Menu/Menu.tsx
+++ b/src/organisms/Menu/Menu.tsx
@@ -1,0 +1,88 @@
+import React, { MouseEvent, useEffect, useState } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import { useNavItemStateContext, usePageOverlayContext } from "../../context";
+import { ROUTE } from "../../routes";
+import { MenuDisplay } from "./menuComponents/MenuDisplay/MenuDisplay";
+import { useMobileScreen, useTabletScreen } from "../../hooks";
+
+export interface Props {
+  closeMenu: VoidFunction;
+}
+
+export const Menu = ({ closeMenu }: Props) => {
+  const { pageOverlayActive, setPageOverlayActive } = usePageOverlayContext();
+  const { navItemActive, setNavItemActive } = useNavItemStateContext();
+  const [isMobileMenuActive, setIsMobileMenuActive] = useState(false);
+  const [lineVisible, setLineVisible] = useState(false);
+  const [selectedItem, setSelectedItem] = useState("");
+  const isTabletScreen = useTabletScreen();
+  const isSmallMobile = useMobileScreen();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const outsourceView = location.pathname === `/${ROUTE.OUTSOURCE}`;
+
+  const toggleMobileMenu = () => {
+    setIsMobileMenuActive(!isMobileMenuActive);
+    setPageOverlayActive(false);
+  };
+
+  const handleActiveNavItem = (e: MouseEvent<Element, MouseEvent>) => {
+    const target = e.currentTarget;
+    const navBtnPath = target.getAttribute("data-path");
+
+    setSelectedItem(target.id);
+
+    if (navBtnPath) {
+      navigate(navBtnPath);
+    }
+    if (target.id === selectedItem) {
+      setNavItemActive(!navItemActive);
+      if (navBtnPath) {
+        setPageOverlayActive(false);
+      } else setPageOverlayActive(!pageOverlayActive);
+    }
+    if (target.id !== selectedItem) {
+      setNavItemActive(true);
+      if (navBtnPath) {
+        setPageOverlayActive(false);
+      } else setPageOverlayActive(true);
+    }
+  };
+
+  useEffect(() => {
+    if (!isTabletScreen) {
+      setIsMobileMenuActive(false);
+    }
+    setIsMobileMenuActive(false);
+    closeMenu();
+  }, [isTabletScreen]);
+
+  const setLine = () => {
+    if (window.scrollY > 66) {
+      setLineVisible(true);
+    } else {
+      setLineVisible(false);
+    }
+  };
+
+  useEffect(() => {
+    window.addEventListener("scroll", setLine);
+    return () => {
+      window.removeEventListener("scroll", setLine);
+    };
+  }, []);
+
+  return (
+    <MenuDisplay
+      navItemActive={navItemActive}
+      isMobileMenuActive={isMobileMenuActive}
+      lineVisible={lineVisible}
+      isSmallMobile={isSmallMobile}
+      outsourceView={outsourceView}
+      selectedItem={selectedItem}
+      toggleMobileMenu={toggleMobileMenu}
+      handleCloseMenu={closeMenu}
+      handleActiveNavItem={handleActiveNavItem}
+    />
+  );
+};

--- a/src/organisms/Menu/index.ts
+++ b/src/organisms/Menu/index.ts
@@ -1,0 +1,1 @@
+export { Menu } from "./Menu";

--- a/src/organisms/Menu/menuComponents/DevelopersGrid/DevelopersGrid.stories.tsx
+++ b/src/organisms/Menu/menuComponents/DevelopersGrid/DevelopersGrid.stories.tsx
@@ -1,0 +1,33 @@
+import React, { useContext } from "react";
+import { Meta, Story } from "@storybook/react";
+import { BrowserRouter } from "react-router-dom";
+import { DevelopersGrid, Props } from "./DevelopersGrid";
+import { StyledResponsiveContainer } from "../../../../components/atoms";
+
+export default {
+  title: "Organisms/Menu/menuComponents/DevelopersGrid",
+  component: DevelopersGrid,
+  argTypes: {
+    variant: {
+      options: ["clickable-cards", "default"],
+      control: { type: "select" },
+    },
+  },
+} as Meta;
+
+const Template: Story = (args: Props) => {
+  return (
+    <BrowserRouter>
+      <div className="container">
+        <StyledResponsiveContainer>
+          <DevelopersGrid {...args} />
+        </StyledResponsiveContainer>
+      </div>
+    </BrowserRouter>
+  );
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  variant: "default",
+};

--- a/src/organisms/Menu/menuComponents/DevelopersGrid/DevelopersGrid.tsx
+++ b/src/organisms/Menu/menuComponents/DevelopersGrid/DevelopersGrid.tsx
@@ -1,0 +1,103 @@
+import React, { MouseEvent, useState } from "react";
+import { v4 as uuidv4 } from "uuid";
+import { developers } from "../../../../assets/content/developers";
+import { devices } from "../../../../assets/images";
+import { Image, Typography } from "../../../../components/atoms";
+import { ListItem } from "../../../../components/molecules";
+import { theme } from "../../../../themes/MainTheme";
+import { Link } from "react-router-dom";
+import { useLaptopScreen } from "../../../../hooks";
+import { DevelopersGridVariant } from "../../../../types/developersGridTypes";
+import {
+  StyledDevelopersGrid,
+  StyledDevelopersWrapper,
+  StyledTitle,
+  StyledDescription,
+  StyledListOuter,
+  StyledImageWrapper,
+  StyledListInner,
+} from "./StyledDevelopersGrid";
+
+export interface Props {
+  variant?: DevelopersGridVariant;
+}
+
+export const DevelopersGrid = ({ variant }: Props) => {
+  const [devClicked, setDevClicked] = useState(false);
+  const [selectedItem, setSelectedItem] = useState("");
+  const largeScreen = useLaptopScreen();
+
+  const handleSelectedItem = (e: MouseEvent<Element, MouseEvent>) => {
+    const target = e.currentTarget.id;
+    setSelectedItem(target);
+    setDevClicked(!devClicked);
+  };
+
+  return (
+    <StyledDevelopersWrapper>
+      <StyledTitle>
+        <Typography
+          as="p"
+          variant="body_text_2"
+          color={theme.colors.gray400}
+          textTransform="uppercase"
+        >
+          Hire Developers
+        </Typography>
+      </StyledTitle>
+      <StyledDevelopersGrid
+        className={`${variant} ${devClicked ? `active-${selectedItem}` : ""}`}
+        id={selectedItem}
+      >
+        {developers.map((dev) => (
+          <StyledListOuter
+            onMouseLeave={() => {
+              largeScreen && setDevClicked(false);
+            }}
+            key={dev.id}
+            className={`grid-area ${variant} ${
+              devClicked && dev.id === selectedItem ? "active" : ""
+            }`}
+          >
+            <ListItem
+              variant="icon-left larger-to-smaller"
+              listItem={dev.type}
+              icon={dev.icon}
+              iconWidth="1.8rem"
+              onClick={handleSelectedItem}
+              hover
+              id={dev.id}
+            />
+            {variant === "clickable-cards" && largeScreen && (
+              <StyledDescription
+                className={`${variant} ${devClicked && dev.id === selectedItem ? "active" : ""}`}
+              >
+                <Typography as="p" variant="body_text_7" color={theme.colors.gray600}>
+                  {dev.description}
+                </Typography>
+              </StyledDescription>
+            )}
+            <StyledListInner
+              className={`${variant} ${devClicked && dev.id === selectedItem ? "active" : ""}`}
+            >
+              {dev.role.map((role) => (
+                <Link to={role.path} key={uuidv4()}>
+                  <ListItem variant="plain arrow" listItem={role.title} hover />
+                </Link>
+              ))}
+            </StyledListInner>
+          </StyledListOuter>
+        ))}
+        {largeScreen && (
+          <StyledImageWrapper className={`grid-area ${variant}`}>
+            <Image
+              src={devices}
+              alt="devices"
+              label="Lorem ipsum dolor sit amet, consectetur adipiscing elit"
+            />
+          </StyledImageWrapper>
+        )}
+      </StyledDevelopersGrid>
+    </StyledDevelopersWrapper>
+  );
+};

--- a/src/organisms/Menu/menuComponents/DevelopersGrid/StyledDevelopersGrid.tsx
+++ b/src/organisms/Menu/menuComponents/DevelopersGrid/StyledDevelopersGrid.tsx
@@ -1,0 +1,142 @@
+import styled from "styled-components";
+import { device } from "../../../../utils/devices/devices";
+import { StyledResponsiveContainer } from "../../../../components/atoms";
+import { theme } from "../../../../themes/MainTheme";
+
+export const StyledDevelopersWrapper = styled(StyledResponsiveContainer)`
+  padding: 0;
+  @media ${device.laptop} {
+    margin: 0 auto;
+    padding: 4rem 0;
+  }
+`;
+
+export const StyledTitle = styled.div`
+  display: none;
+  padding-left: 3rem;
+  margin-bottom: 1.5rem;
+  @media ${device.laptop} {
+    display: block;
+  }
+`;
+
+export const StyledListOuter = styled.ul`
+  padding: 1.5rem;
+  margin: 0;
+  &:hover {
+    background-color: ${theme.colors.blueTransparent};
+    transition: all 0.3s;
+    border-radius: 4px;
+  }
+  &.clickable-cards {
+    display: none;
+    @media ${device.laptop} {
+      display: block;
+    }
+  }
+`;
+
+export const StyledListInner = styled.ul`
+  padding-left: 3.5rem;
+  margin: 1rem 0 0 0;
+  &.clickable-cards {
+    display: none;
+    &.active {
+      display: block;
+    }
+  }
+`;
+
+export const StyledDescription = styled.div`
+  width: auto;
+  height: auto;
+  padding: 0.5rem 1.5rem 1.5rem 3.8rem;
+  &.active {
+    display: none;
+  }
+`;
+
+export const StyledImageWrapper = styled.div`
+  img {
+    margin-bottom: 2rem;
+    height: 18.8rem;
+  }
+  &.clickable-cards {
+    margin-top: -80%;
+  }
+`;
+
+export const StyledDevelopersGrid = styled(StyledResponsiveContainer)`
+  display: grid;
+  grid-gap: 0.5rem;
+  grid-template-areas: "a" "b" "c" "d" "e" "f";
+  .grid-area {
+    &:first-child {
+      grid-area: a;
+    }
+    &:nth-child(2) {
+      grid-area: b;
+    }
+    &:nth-child(3) {
+      grid-area: c;
+    }
+    &:nth-child(4) {
+      grid-area: d;
+    }
+    &:nth-child(5) {
+      grid-area: e;
+    }
+    &:nth-child(6) {
+      grid-area: f;
+    }
+    &:nth-child(7) {
+      grid-area: g;
+    }
+    @media ${device.laptop} {
+      width: 26rem;
+    }
+  }
+  @media ${device.tablet} {
+    grid-template-areas: "a b c g" "d e f g";
+  }
+  @media ${device.laptop} {
+    grid-template-areas: "a b c g" "d e f g";
+    margin-top: 1.5rem;
+    padding: 0 1.5rem;
+    &.clickable-cards {
+      &.active-devs-1 {
+        grid-template-areas:
+          "a b c g"
+          "a e f g";
+        .grid-area:nth-child(4) {
+          display: none;
+        }
+        .grid-area:nth-child(1) {
+          height: max-content;
+        }
+      }
+      &.active-devs-2 {
+        grid-template-areas:
+          "a b c g"
+          "d b f g";
+        .grid-area:nth-child(5) {
+          display: none;
+        }
+        .grid-area:nth-child(2) {
+          height: max-content;
+        }
+      }
+      &.active-devs-3 {
+        grid-template-areas:
+          "a b c g"
+          "d e c g";
+        .grid-area:nth-child(6) {
+          display: none;
+        }
+        .grid-area:nth-child(3) {
+          height: max-content;
+        }
+      }
+    }
+  }
+`;

--- a/src/organisms/Menu/menuComponents/MenuContent/MenuContent.tsx
+++ b/src/organisms/Menu/menuComponents/MenuContent/MenuContent.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useRef, useState } from "react";
+import { v4 as uuidv4 } from "uuid";
+import { Link } from "react-router-dom";
+import { Typography } from "../../../../components/atoms";
+import { Card } from "../../../../components/molecules";
+import { DevelopersGrid } from "../DevelopersGrid/DevelopersGrid";
+import { whatWeDoCards, aboutUsCards } from "../../../../assets/content/navMenu/cards";
+import { StyledMenuContent, StyledTitle, StyledCardsWrapper, Wrapper } from "./StyledMenuContent";
+import { theme } from "../../../../themes/MainTheme";
+import { useLaptopScreen } from "../../../../hooks";
+
+interface Props {
+  navItemActive?: boolean;
+  selectedItem: string;
+  label?: string;
+  cardsList?: any;
+}
+
+export const MenuContent = ({ navItemActive, selectedItem }: Props) => {
+  const laptopScreen = useLaptopScreen();
+  const [droppedItemId, setDroppedItemId] = useState("");
+  const selectedItemRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const target = selectedItemRef.current;
+    const targetId = target?.id;
+    targetId && setDroppedItemId(targetId);
+  }, [selectedItem]);
+
+  return (
+    <StyledMenuContent className={navItemActive ? "active" : ""}>
+      <Wrapper
+        className={droppedItemId === selectedItem ? "animate" : ""}
+        id={selectedItem}
+        ref={selectedItemRef}
+      >
+        {selectedItem === "menu-2" ? (
+          <DevelopersGrid />
+        ) : (
+          <>
+            <StyledTitle>
+              <Typography
+                as="p"
+                variant="body_text_2"
+                color={theme.colors.gray400}
+                textTransform="uppercase"
+              >
+                {selectedItem === "menu-1" && "What we do"}
+                {selectedItem === "menu-5" && "About us"}
+              </Typography>
+            </StyledTitle>
+            <StyledCardsWrapper>
+              {(selectedItem === "menu-1" ? whatWeDoCards : aboutUsCards).map((card) => (
+                <Link to={card.path} key={uuidv4()}>
+                  <Card title={card.title} variant="medium-responsive" hover>
+                    <Typography as="p" variant="body_text_7" color={theme.colors.gray600}>
+                      {card.text}
+                    </Typography>
+                  </Card>
+                </Link>
+              ))}
+            </StyledCardsWrapper>
+            {laptopScreen && <DevelopersGrid variant="clickable-cards" />}
+          </>
+        )}
+      </Wrapper>
+    </StyledMenuContent>
+  );
+};

--- a/src/organisms/Menu/menuComponents/MenuContent/StyledMenuContent.tsx
+++ b/src/organisms/Menu/menuComponents/MenuContent/StyledMenuContent.tsx
@@ -1,0 +1,48 @@
+import styled from "styled-components";
+import { StyledResponsiveContainer } from "../../../../components/atoms";
+import { navItemFadeIn, navItemSlideDown, navItemSlideUp } from "../../../../keyframes";
+import { device } from "../../../../utils";
+
+export const StyledMenuContent = styled(StyledResponsiveContainer)`
+  height: max-content;
+  transform: translateY(-1000px);
+  animation: ${navItemSlideUp} 0.2s linear backwards;
+  padding: 0;
+  &.active {
+    animation: ${navItemSlideDown} 0.2s ease 0.2s forwards;
+  }
+  @media ${device.laptop} {
+    margin: 0 auto;
+    padding: 4rem 0;
+  }
+`;
+
+export const Wrapper = styled.div`
+  opacity: 0;
+  &.animate {
+    animation: ${navItemFadeIn} 0.8s ease forwards;
+  }
+`;
+
+export const StyledTitle = styled.div`
+  padding-left: 3rem;
+  margin-bottom: 1.5rem;
+  display: none;
+  @media ${device.laptop} {
+    display: block;
+  }
+`;
+
+export const StyledCardsWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  @media ${device.tablet} {
+    flex-direction: row;
+    flex-wrap: nowrap;
+    width: 67%;
+  }
+  @media ${device.laptop} {
+    width: 50%;
+    padding: 0 1.5rem;
+  }
+`;

--- a/src/organisms/Menu/menuComponents/MenuDisplay/MenuDisplay.tsx
+++ b/src/organisms/Menu/menuComponents/MenuDisplay/MenuDisplay.tsx
@@ -1,0 +1,79 @@
+import React, { MouseEvent } from "react";
+import { sofomo } from "../../../../assets/logos/logotypes";
+import { greenBadge, menu } from "../../../../assets/icons";
+import { Link } from "react-router-dom";
+import { ROUTE } from "../../../../routes";
+import { Typography, Image } from "../../../../components/atoms";
+import { NavList } from "../NavList/NavList";
+import { theme } from "../../../../themes/MainTheme";
+import { MenuContent } from "../MenuContent/MenuContent";
+import {
+  StyledMenuDisplay,
+  StyledNavPositionWrapper,
+  StyledMenuBarDisplayWrapper,
+  StyledBars,
+  StyledContentLaptopWrapper,
+  StyledOutsourceTopTitle,
+} from "./StyledMenuDisplay";
+
+interface MenuProps {
+  navItemActive: boolean;
+  isMobileMenuActive: boolean;
+  lineVisible: boolean;
+  isSmallMobile: boolean;
+  outsourceView: boolean;
+  selectedItem: string;
+  toggleMobileMenu: VoidFunction;
+  handleCloseMenu: VoidFunction;
+  handleActiveNavItem: (e: MouseEvent<Element, MouseEvent>) => void;
+}
+export const MenuDisplay = ({
+  navItemActive,
+  isMobileMenuActive,
+  lineVisible,
+  isSmallMobile,
+  outsourceView,
+  selectedItem,
+  toggleMobileMenu,
+  handleCloseMenu,
+  handleActiveNavItem,
+}: MenuProps) => {
+  return (
+    <StyledMenuDisplay
+      className={`${navItemActive || isMobileMenuActive ? "active" : ""} ${
+        lineVisible ? "line-visible" : ""
+      }`}
+    >
+      <StyledMenuBarDisplayWrapper>
+        <Link to={ROUTE.HOME_PAGE} onClick={handleCloseMenu}>
+          <Image width="10.3rem" height="2.3rem" src={sofomo} alt="sofomo" />
+        </Link>
+        {outsourceView ? (
+          <StyledOutsourceTopTitle>
+            <Image width="1.8rem" src={greenBadge} alt="" />
+            <Typography variant="body_text_5" fontWeight="700" color={theme.colors.gray400}>
+              Outsource development partner for 10+ years
+            </Typography>
+          </StyledOutsourceTopTitle>
+        ) : (
+          <>
+            <StyledNavPositionWrapper>
+              <NavList
+                handleActiveNavItem={handleActiveNavItem}
+                selectedItem={selectedItem}
+                navItemActive={navItemActive}
+                isMenuActive={isMobileMenuActive}
+              />
+              <StyledContentLaptopWrapper className={navItemActive ? "active-laptop" : ""}>
+                <MenuContent navItemActive={navItemActive} selectedItem={selectedItem} />
+              </StyledContentLaptopWrapper>
+            </StyledNavPositionWrapper>
+            <StyledBars onClick={toggleMobileMenu}>
+              <Image src={menu} alt="menu" />
+            </StyledBars>
+          </>
+        )}
+      </StyledMenuBarDisplayWrapper>
+    </StyledMenuDisplay>
+  );
+};

--- a/src/organisms/Menu/menuComponents/MenuDisplay/StyledMenuDisplay.tsx
+++ b/src/organisms/Menu/menuComponents/MenuDisplay/StyledMenuDisplay.tsx
@@ -1,0 +1,116 @@
+import styled from "styled-components";
+import { theme } from "../../../../themes/MainTheme";
+import { device } from "../../../../utils/devices/devices";
+import { menuLineFadeIn, menuLineFadeOut } from "../../../../keyframes";
+import { StyledResponsiveContainer } from "../../../../components/atoms";
+
+export const StyledMenuDisplay = styled.nav`
+  width: 100%;
+  margin: 0 auto;
+  min-width: 34.5rem;
+  position: fixed;
+  top: 3rem;
+  left: 0;
+  z-index: 40;
+  background-color: ${theme.colors.white};
+  height: 6.6rem;
+  &:after {
+    content: "";
+    width: 100%;
+    height: 1px;
+    position: absolute;
+    top: 6.5rem;
+    left: 0;
+    z-index: 21;
+    animation: ${menuLineFadeOut} 0.3s ease-out 0.3s 1 backwards;
+  }
+  &.active,
+  &.line-visible {
+    &:after {
+      animation: ${menuLineFadeIn} 0.3s ease-out 0.2s 1 forwards;
+    }
+  }
+  @media ${device.tablet} {
+    height: 8rem;
+    width: 100vw;
+    &:after {
+      top: 7.9rem;
+    }
+  }
+`;
+
+export const StyledMenuBarDisplayWrapper = styled(StyledResponsiveContainer)`
+  padding: 0 1.5rem;
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  align-items: center;
+  position: relative;
+  height: 6.6rem;
+  @media ${device.tablet} {
+    height: 8rem;
+    padding: 0 3rem;
+  }
+`;
+
+export const StyledNavPositionWrapper = styled.div`
+  background-color: ${theme.colors.white};
+  height: 3.6rem;
+  overflow-y: hidden;
+  min-width: 37.5rem;
+  @media (max-width: 1094px) {
+    position: absolute;
+    top: 8rem;
+    left: 0;
+    left: calc(-1 * ((100vw - 768px) / 2));
+    width: 100vw;
+    height: auto;
+  }
+  @media (max-width: 768px) {
+    width: 100vw;
+    top: 6.6rem;
+    left: 0;
+  }
+`;
+
+export const StyledContentLaptopWrapper = styled.div`
+  @media ${device.mobile} {
+    max-height: 0;
+  }
+  position: absolute;
+  top: 6.6rem;
+  width: 100vw;
+  left: calc(-1 * ((100vw - 1094px) / 2));
+  background-color: ${theme.colors.white};
+  overflow: hidden;
+  @media ${device.laptop} {
+    max-height: 0;
+    transition: max-height 0.3s;
+    transition-delay: 0.1s;
+    top: 8rem;
+    box-shadow: 0px 18px 40px -15px rgba(50, 49, 94, 0.2);
+    &.active-laptop {
+      box-shadow: 0px 18px 40px -15px rgba(50, 49, 94, 0.2);
+      transition: max-height 0.3s;
+      max-height: 1200px;
+    }
+  }
+`;
+
+export const StyledBars = styled.div`
+  width: 2.4rem;
+  height: 2.4rem;
+  display: block;
+  cursor: pointer;
+  @media ${device.laptop} {
+    display: none;
+  }
+`;
+
+export const StyledOutsourceTopTitle = styled.div`
+  display: none;
+  @media ${device.tablet} {
+    display: block;
+  }
+`;

--- a/src/organisms/Menu/menuComponents/NavList/NavList.tsx
+++ b/src/organisms/Menu/menuComponents/NavList/NavList.tsx
@@ -1,0 +1,68 @@
+import React, { MouseEvent } from "react";
+import { mainMenu } from "../../../../assets/content/navMenu/mainMenu";
+import { ListItem, List } from "../../../../components/molecules";
+import { Button } from "../../../../components/atoms";
+import { MenuContent } from "../MenuContent/MenuContent";
+import { useContactFormContext } from "../../../../context/ContactFormContext";
+import {
+  StyledDividerLine,
+  StyledNavList,
+  StyledMobileContentWrapper,
+  StyledMobileContent,
+} from "./StyledNavList";
+
+interface Props {
+  handleActiveNavItem?: (e: MouseEvent<Element, MouseEvent>) => void;
+  selectedItem?: string;
+  navItemActive?: boolean;
+  isMenuActive?: boolean;
+}
+
+export const NavList = ({
+  handleActiveNavItem,
+  selectedItem = "",
+  navItemActive,
+  isMenuActive,
+}: Props) => {
+  const { setFormActive } = useContactFormContext();
+
+  return (
+    <StyledNavList className={isMenuActive ? "active" : ""}>
+      <List variant="navlist" margin="0">
+        {mainMenu.map((navItem) => (
+          <StyledMobileContentWrapper
+            key={navItem.id}
+            className={selectedItem === navItem.id && navItemActive ? "active" : ""}
+          >
+            <ListItem
+              margin="0 0.5rem 1.5rem"
+              variant={navItem.chevron ? "dropdown-chevrons" : "dropdown-no-chevrons"}
+              listItem={navItem.title}
+              key={navItem.id}
+              id={navItem.id}
+              onClick={handleActiveNavItem}
+              dropdownActive={selectedItem === navItem.id && navItemActive}
+              path={navItem.path}
+              data-path={navItem.path}
+              cursorPointer
+            />
+            {navItem.chevron && (
+              <StyledMobileContent
+                className={selectedItem === navItem.id && navItemActive ? "active" : ""}
+              >
+                <MenuContent selectedItem={selectedItem} navItemActive={navItemActive} />
+              </StyledMobileContent>
+            )}
+            <StyledDividerLine />
+          </StyledMobileContentWrapper>
+        ))}
+        <Button
+          variant="secondary"
+          label="Contact Us"
+          margin="4rem 0 0 0"
+          onClick={() => setFormActive(true)}
+        />
+      </List>
+    </StyledNavList>
+  );
+};

--- a/src/organisms/Menu/menuComponents/NavList/StyledNavList.tsx
+++ b/src/organisms/Menu/menuComponents/NavList/StyledNavList.tsx
@@ -1,0 +1,53 @@
+import styled from "styled-components";
+import { theme } from "../../../../themes/MainTheme";
+import { device } from "../../../../utils";
+import { StyledResponsiveContainer } from "../../../../components/atoms";
+
+export const StyledNavList = styled(StyledResponsiveContainer)`
+  width: 100%;
+  height: 0;
+  &.active {
+    height: 100vh;
+    overflow-y: scroll;
+    padding-bottom: 4.5rem;
+  }
+  @media ${device.laptop} {
+    height: 3.6rem;
+    padding: 0;
+  }
+`;
+
+export const StyledMobileContentWrapper = styled.div`
+  margin-bottom: 5px;
+  position: relative;
+  @media ${device.laptop} {
+    margin: 0;
+  }
+`;
+
+export const StyledMobileContent = styled.div`
+  width: 100%;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.5s;
+  transition-delay: 0.1s;
+  &.active {
+    transition: max-height 0.3s;
+    max-height: 1200px;
+  }
+  @media ${device.laptop} {
+    display: none;
+  }
+`;
+
+export const StyledDividerLine = styled.div`
+  width: 100%;
+  height: 1px;
+  background-color: ${theme.colors.gray100};
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  @media ${device.laptop} {
+    display: none;
+  }
+`;

--- a/src/organisms/index.ts
+++ b/src/organisms/index.ts
@@ -2,3 +2,4 @@ export { NestedDropdownList } from "./NestedDropdownList";
 export { ContactModal } from "./ContactModal";
 export { ContactFormik } from "./ContactFormik";
 export { Footer } from "./Footer";
+export { Menu } from "./Menu";

--- a/src/types/developersGridTypes.ts
+++ b/src/types/developersGridTypes.ts
@@ -1,0 +1,1 @@
+export type DevelopersGridVariant = "clickable-cards";

--- a/src/types/listTypes.ts
+++ b/src/types/listTypes.ts
@@ -2,8 +2,6 @@ export type ListVariants =
   | "in-dropdown"
   | "split"
   | "standard"
-  | "standard developers inner"
-  | "standard developers outer"
   | "plain"
   | "dropdown-outer"
   | "double-list"


### PR DESCRIPTION
This is the full menu, I created this branch not from main, but from DevelopersGrid, as the menu needs it.

I didn't know how to split it into smaller parts, as components are too connected to each other. 

**Just to describe what it going on there.**

The **_Menu_** component keeps the whole logic, and renders **_MenuDisplay._**

**_MenuDisplay_** renders and sets positions for menu elements, and displays them conditionally:

 1. On the mobile screen it should show: the logo and hamburger menu,
 2. On the desktop screen it should show : the logo and menu items list. 
 3. When the location path is "/outsource" menu should not display at all, but instead there is just some text.

The _menu list_ and the _list items content_, display differently depending on screen size. So to achieve the designed functionality I did it like that: 

I created a component called MenuContent that is responsible for displaying the menu items' content ( if there is any, as some menu items are just links without content). The content is displayed according to the currently selected by click, item.


And now I use this MenuContent twofold:

**For mobile**:  Inside **_NavMenu_** component - as the part of the menu item. Initially, on a mobile screen, the item content is not visible but is toggled when the item is clicked. So what we see after the click, is what the MenuContent gives. 
This MenuContent should not be there when the screen is desktop,  so it is displayed "none" in a media query ( I am not sure, maybe it would be better to render this component conditionally in JSX instead?)

**For desktop**: NavMenu component for desktop displays only nav items, as the MenuContent is displayed to none on that screen size. So what we see after clicking the nav item, is not a part of the NavMenu component like it was on a mobile screen, but the content is displayed as a sibling to NavMenu, and clicking makes the menu content open in a different place, but still what we see in there is what we get from MenuContent.


About the logic : 
- I use there two contexts: 

a ) the first one is page overlay, what is does, it sets the overlay on the page when the desktop menu is open. The 
    overlay is not created yet, it is gonna be added inside the page template, so in a totally different place, and clicking 
    on that will change the state of the menu( should close the menu). 

b) the second one NavItemContext, I use it in many different places, so I placed the state in the context to avoid passing  
    the props too many times. 

Both states kept by those contexts could be used on the top-level that is gonna be PageTemplate, but with the complexity of Menu  it was much easier for me to keep track of all the menu states this way. 

- The function that is responsible for setting active nav item and giving or taking an active class to it is **_handleActiveNavItem_**, after many different variations of  "ifs", this final combination works well. I use there a **"data-path"** attribute - the reason for that is I needed some selector for this function to know, that this particular element should not open any MenuContent component , and should close the page overlay.  Basically, it tells the function, if this item has a link, it means we don't want any action that would be triggered otherwise.

You can fire this in storybook, to see how this works.
